### PR TITLE
Import constants into Delta index.html, reduce Delta's ambient sound volume

### DIFF
--- a/src/worlds/BW_Delta/index.html
+++ b/src/worlds/BW_Delta/index.html
@@ -9,7 +9,8 @@
     <!-- <script src="/worlds/hub/scripts/hub.js"></script> -->
     <script src="/worlds/BW_Delta/js/orbmanager.js"></script>]
     <script src="/worlds/BW_Delta/js/memory-core.js"></script> 
-    <script src="/worlds/BW_Delta/js/orb-release.js"></script> 
+    <script src="/worlds/BW_Delta/js/orb-release.js"></script>
+    <script src="js/constants.js"></script>
 
     <script src="https://unpkg.com/aframe-environment-component@1.3.3/dist/aframe-environment-component.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-particle-system-component@master/dist/aframe-particle-system-component.min.js"></script>
@@ -112,8 +113,8 @@
       </a-entity>
 
       <!-- Sound entities -->
-      <a-entity id="ambience-player" circles-sound="src:#delta-ambient-sound; autoplay: true; loop: true; type: music;"></a-entity>
-      <a-entity id="heartbeats-player" circles-sound="src:#delta-heartbeats; autoplay: true; loop: true; type: music;"></a-entity>
+      <a-entity id="ambience-player" circles-sound="src:#delta-ambient-sound; autoplay: true; loop: true; type: music; volume: 0.5;"></a-entity>
+      <a-entity id="heartbeats-player" circles-sound="src:#delta-heartbeats; autoplay: true; loop: true; type: music; volume: 0.5;"></a-entity>
 
       <!-- Orb clips -->
       <a-entity id="clip1" circles-sound="src:#orb-clip1; autoplay: false; loop: false; type: soundeffect; poolsize:4"></a-entity>


### PR DESCRIPTION
* There was a missing import for js/constants which contained the guiding text
* This caused the orbs to not spawn since the GUIDING_TEXT constant was undefined

Before:
![image](https://github.com/user-attachments/assets/d4bc3f50-3bff-4f62-be65-9104833f956c)

After:
![image](https://github.com/user-attachments/assets/edb74b9f-4541-49ad-b97e-4174693cbb99)
