### PR TITLE
Fix circles-networked-basic, add networking to emotion orbs in main hub

### DIFF
--- a/src/components/circles-networked-basic.js
+++ b/src/components/circles-networked-basic.js
@@ -24,6 +24,11 @@ AFRAME.registerComponent('circles-networked-basic', {
     let regex = /(naf)/i;
     CONTEXT_AF.isClone  = regex.test(CONTEXT_AF.el.id); //if false, this entity is the sole networked object of all duplicates
 
+    //this is so we can keep track of which world this object is from so we can share objects, but turning that off for now to reduce duplicate object complexity.
+    if (CONTEXT_AF.isClone === false) {
+      CONTEXT_AF.el.setAttribute('circles-object-world', {});
+    }
+
     if (CIRCLES.isCirclesWebsocketReady()) {
       CONTEXT_AF.createEventFunctions();    //will only do this once at beginning of program
     }
@@ -33,11 +38,6 @@ AFRAME.registerComponent('circles-networked-basic', {
         CONTEXT_AF.el.sceneEl.removeEventListener(CIRCLES.EVENTS.WS_CONNECTED, wsReadyFunc);
       };
       CONTEXT_AF.el.sceneEl.addEventListener(CIRCLES.EVENTS.WS_CONNECTED, wsReadyFunc);
-    }
-
-    //this is so we can keep track of which world this object is from so we can share objects, but turning that off for now to reduce duplicate object complexity.
-    if (CONTEXT_AF.isClone === false) {
-      CONTEXT_AF.el.setAttribute('circles-object-world', {});
     }
   },
   update : function(oldData) {

--- a/src/worlds/BW_Hub/js/dispense-emotion.js
+++ b/src/worlds/BW_Hub/js/dispense-emotion.js
@@ -7,19 +7,41 @@ AFRAME.registerComponent('dispense-emotion', {
     },
 
     init: function () {
-      const CONTEXT_AF = this;
-      CONTEXT_AF.guidingText = document.querySelector('[bw-guiding-text]').components['bw-guiding-text'];
+        const CONTEXT_AF = this;
+        CONTEXT_AF.guidingText = document.querySelector('[bw-guiding-text]').components['bw-guiding-text'];
 
-      CONTEXT_AF.el.addEventListener('click', function() {
-        //dispose a ball if the slot is empty
-        if(CONTEXT_AF.data.enabled) {
-            CONTEXT_AF.createOrb();
-            CONTEXT_AF.el.setAttribute('dispense-emotion', {enabled: false})
+        CONTEXT_AF.socket     = null;
+        CONTEXT_AF.connected  = false;
+
+        // Get socket so we can get the socket ID to add a unique identifier to the created orb
+        CONTEXT_AF.createNetworkingSystem = function () {
+            CONTEXT_AF.socket = CIRCLES.getCirclesWebsocket();
+            CONTEXT_AF.connected = true;
+            // console.warn("messaging system connected at socket: " + CONTEXT_AF.socket.id + " in room:" + CIRCLES.getCirclesGroupName() + ' in world:' + CIRCLES.getCirclesWorldName());
         }
-        //display error text if the slot is filled
-        else
-            CONTEXT_AF.guidingText.displayError(ERROR_TEXT.DISPOSE_ONE_TYPE_PART1 + CONTEXT_AF.data.emotion + ERROR_TEXT.DISPOSE_ONE_TYPE_PART2);
-      })
+
+        //check if circle networking is ready. If not, add an went to listen for when it is ...
+        if (CIRCLES.isCirclesWebsocketReady()) {
+            CONTEXT_AF.createNetworkingSystem();
+        }
+        else {
+            const wsReadyFunc = async function() {
+                CONTEXT_AF.createNetworkingSystem();
+                CONTEXT_AF.el.sceneEl.removeEventListener(CIRCLES.EVENTS.WS_CONNECTED, wsReadyFunc);
+            };
+            CONTEXT_AF.el.sceneEl.addEventListener(CIRCLES.EVENTS.WS_CONNECTED, wsReadyFunc);
+        }
+
+        CONTEXT_AF.el.addEventListener('click', function() {
+            //dispose a ball if the slot is empty
+            if(CONTEXT_AF.data.enabled) {
+                CONTEXT_AF.createOrb();
+                CONTEXT_AF.el.setAttribute('dispense-emotion', {enabled: false})
+            }
+            //display error text if the slot is filled
+            else
+                CONTEXT_AF.guidingText.displayError(ERROR_TEXT.DISPOSE_ONE_TYPE_PART1 + CONTEXT_AF.data.emotion + ERROR_TEXT.DISPOSE_ONE_TYPE_PART2);
+        })
     },
 
     //function creates an orb and positions it in the dispenser slot
@@ -36,7 +58,10 @@ AFRAME.registerComponent('dispense-emotion', {
         orbEl.setAttribute('material', {color: CONTEXT_AF.data.orbColour});
         orbEl.setAttribute('emotion-pick-up', {animate:true});
         orbEl.setAttribute('circles-interactive-object', {type: 'outline'});
-        orbEl.setAttribute('id', CONTEXT_AF.data.emotion);
+        // Set id for orb that is the emotion + the socket id so the orb is uniquely identified when networked across clients
+        orbEl.setAttribute('id', `${CONTEXT_AF.data.emotion}-${CONTEXT_AF.socket.id}`);
+        // Set a new 'data-emotion' attribute on the orb so the attribute can be referenced when the orb's emotion is shared in the emotion data update logic
+        orbEl.setAttribute('data-emotion', CONTEXT_AF.data.emotion);
 
         CONTEXT_AF.parent.appendChild(orbEl);
     }

--- a/src/worlds/BW_Hub/js/emotion-pick-up.js
+++ b/src/worlds/BW_Hub/js/emotion-pick-up.js
@@ -14,8 +14,9 @@ AFRAME.registerComponent('emotion-pick-up', {
         if(holdingAnotherOrb) {
           CONTEXT_AF.guidingText.displayError(ERROR_TEXT.PICK_UP_ONE);
         }
-        else 
+        else {
           CONTEXT_AF.pickUp(CONTEXT_AF.el, CONTEXT_AF.camera, CONTEXT_AF.manager);
+        }
       })
       
     },
@@ -23,11 +24,19 @@ AFRAME.registerComponent('emotion-pick-up', {
     pickUp: function (orb, camera, manager) {
       const CONTEXT_AF = this;
       
+      // Make orb no longer interactive once it is picked up
       orb.removeAttribute('circles-interactive-object');
+
+      // Add component to network the orb so it is visible across clients once it is picked up
+      orb.setAttribute('circles-networked-basic', {});
+
+      // Parent the orb to the camera and set the position and scale accordingly
       orb.object3D.parent = camera.object3D;
       orb.object3D.position.set(0, 0, -1);
       orb.object3D.scale.set(2, 2, 2);
-      manager.setAttribute('manager', {holdingOrb: true, holdingOrbId: orb.id});
+      // Set orb states on the manager for whether the user is holding the orb, the orb's ID, and the orb's emotion so it can be used in the emotion data logic
+      manager.setAttribute('manager', {holdingOrb: true, holdingOrbId: orb.id, holdingOrbEmotion: orb.getAttribute('data-emotion')});
+
       if(CONTEXT_AF.room.toLowerCase() == 'hub')
         CONTEXT_AF.guidingText.updateGuidingText(GUIDING_TEXT.SHARE_EMOTION_PART1);
       else

--- a/src/worlds/BW_Hub/js/manager.js
+++ b/src/worlds/BW_Hub/js/manager.js
@@ -1,7 +1,8 @@
 AFRAME.registerComponent('manager', {
     schema: {
       holdingOrb: {type: 'boolean', default: false},
-      holdingOrbId: {type: 'string'}
+      holdingOrbId: {type: 'string'},
+      holdingOrbEmotion: {type: 'string'}
     },
 
     init: function () {
@@ -74,7 +75,7 @@ AFRAME.registerComponent('manager', {
               console.log("No matching case found");
           }
         });
-
+        
         // On connect, get all emotion data and set the central orb visualisation
         // Listen for other people sharing an emotion orb
         // CONTEXT_AF.socket.on(CONTEXT_AF.shareEmotionEventName, async function (data) {

--- a/src/worlds/BW_Hub/js/share-emotion.js
+++ b/src/worlds/BW_Hub/js/share-emotion.js
@@ -31,7 +31,7 @@ AFRAME.registerComponent('share-emotion', {
             //if holding orb then it can be dispensed
             if(holdingOrb) {
               // play sound
-            CONTEXT_AF.el.components.sound.playSound();
+              CONTEXT_AF.el.components.sound.playSound();
               //un-parent orb from user and parent above the suction tube
               const holdingOrbId = manager.getAttribute('manager').holdingOrbId;
               const orb = document.querySelector(`#${holdingOrbId}`);
@@ -44,8 +44,6 @@ AFRAME.registerComponent('share-emotion', {
                 orb.setAttribute('animation', {property: 'position',
                                                 duration: 500,
                                                 to: '0 -2 0'})
-    
-                
               }, 300);
     
               //delete the orb once it's finished animating
@@ -54,10 +52,10 @@ AFRAME.registerComponent('share-emotion', {
                 //TO DO: probably better to make this availble on remove in the orb component
                 orb.parentNode.children[0].setAttribute('dispense-emotion', {enabled: true});
                 orb.parentNode.removeChild(orb);
-                CONTEXT_AF.managerData.updateEmotionData(CONTEXT_AF.data.visualizationID, manager.getAttribute('manager').holdingOrbId);
+                CONTEXT_AF.managerData.updateEmotionData(CONTEXT_AF.data.visualizationID, manager.getAttribute('manager').holdingOrbEmotion);
                 //CONTEXT_AF.visualizationContainer.setAttribute('room', {orbTypeToUpdate: manager.getAttribute('manager').holdingOrbId}) 
-                CONTEXT_AF.socket.emit(CONTEXT_AF.shareEmotionEventName, {orbTypeToUpdate: manager.getAttribute('manager').holdingOrbId, visualizationContainer: CONTEXT_AF.data.visualizationID, room:CIRCLES.getCirclesGroupName(), world:CIRCLES.getCirclesWorldName()});
-                CONTEXT_AF.manager.emit(CONTEXT_AF.shareEmotionEventName, {orbTypeToUpdate: manager.getAttribute('manager').holdingOrbId, visualizationContainer: CONTEXT_AF.data.visualizationID});
+                CONTEXT_AF.socket.emit(CONTEXT_AF.shareEmotionEventName, {orbTypeToUpdate: manager.getAttribute('manager').holdingOrbEmotion, visualizationContainer: CONTEXT_AF.data.visualizationID, room:CIRCLES.getCirclesGroupName(), world:CIRCLES.getCirclesWorldName()});
+                CONTEXT_AF.manager.emit(CONTEXT_AF.shareEmotionEventName, {orbTypeToUpdate: manager.getAttribute('manager').holdingOrbEmotion, visualizationContainer: CONTEXT_AF.data.visualizationID});
                 console.log("emit");
                 CONTEXT_AF.manager.setAttribute('manager', {holdingOrb: false, 
                                                             holdingOrbId: ''});


### PR DESCRIPTION
* Problem: Networking was not implemented for emotion orbs and did not work with `circles-networked-basic`. Previously, the `circles-object-world` component was not being instantiated/added onto the element with a `circles-networked-basic `component attached to it
* Solution:
  * Moved the `isClone `check before the `createEventFunctions()` scope in `circles-networked-basic`
  * Made the emotion orbs have a unique ID based on the emotion and the socket id
  * Added extra schema property in the `manager `component called `holdingOrbEmotion `to track the orb's emotion instead of using `holdingOrbId `since the ID needs to be unique and is no longer just the emotion name
  * Updated emotion data function parameters to refer to `holdingEmotionOrb `instead of `holdingOrbId`

Demo of networked emotion orbs with two clients:
![April 7 Networked emotion orbs](https://github.com/user-attachments/assets/90112235-00f4-4ab3-8e13-4f80d585616c)
